### PR TITLE
Fix unmatched patterns when using option "--operation=set"

### DIFF
--- a/src/data/set.cocci
+++ b/src/data/set.cocci
@@ -19,7 +19,25 @@ p@p1->$attribut += E
 |
 p@p1->$attribut -= E
 |
+p@p1->$attribut *= E
+|
+p@p1->$attribut /= E
+|
+p@p1->$attribut %= E
+|
+p@p1->$attribut <<= E
+|
+p@p1->$attribut >>= E
+|
+p@p1->$attribut &= E
+|
+p@p1->$attribut ^= E
+|
+ ++p@p1->$attribut
+|
 p@p1->$attribut++
+|
+ --p@p1->$attribut
 |
 p@p1->$attribut--
 |
@@ -31,7 +49,25 @@ ps@p1.$attribut += E
 |
 ps@p1.$attribut -= E
 |
+ps@p1.$attribut *= E
+|
+ps@p1.$attribut /= E
+|
+ps@p1.$attribut %= E
+|
+ps@p1.$attribut <<= E
+|
+ps@p1.$attribut >>= E
+|
+ps@p1.$attribut &= E
+|
+ps@p1.$attribut ^= E
+|
+ ++ps@p1.$attribut
+|
 ps@p1.$attribut++
+|
+ --ps@p1.$attribut
 |
 ps@p1.$attribut--
 )


### PR DESCRIPTION
Hi Éric,

Here is a patch which adds the missing operators for the "set" operation.
- Add Coccinelle patterns to match all assignment operators (<<=, etc.).
- Add patterns to match increment/decrement operators (++ and --).
