### PR TITLE
Fix context line numbers

### DIFF
--- a/src/coccigrep.py
+++ b/src/coccigrep.py
@@ -147,13 +147,13 @@ class CocciMatch:
             if mode == 'color':
                 output += lines[i]
             elif mode == 'vim':
-                output += "%s|%s| (%s %s%s): %s" % (self.file, self.line,
+                output += "%s|%s| (%s %s%s): %s" % (self.file, i + 1,
                 stype, ptype, pmatch, lines[i])
             elif mode == 'emacs':
-                output += "%s:%s: (%s %s%s): %s" % (self.file, self.line,
+                output += "%s:%s: (%s %s%s): %s" % (self.file, i + 1,
                 stype, ptype, pmatch, lines[i])
             else:
-                output += "%s:%s (%s %s%s): %s" % (self.file, self.line,
+                output += "%s:%s (%s %s%s): %s" % (self.file, i + 1,
                 stype, ptype, pmatch, lines[i])
         f.close()
         if mode == 'color':


### PR DESCRIPTION
Hi Regit,

Here is a fix to display the right line numbers when using context options (as previous versions did always print the line number of the matched string rather than the context line).

Code handling Emacs and Vim outputs are modified for consistency, even though coccigrep forces context to 0 if the corresponding options are used.
