### PR TITLE
Remove matched information from context lines

### DIFF
--- a/src/coccigrep.py
+++ b/src/coccigrep.py
@@ -160,8 +160,8 @@ class CocciMatch:
                 output += "%s:%s (%s %s%s): %s" % (self.file, i + 1,
                 stype, ptype, pmatch, lines[i])
             else:
-                output += "%s-%s (%s %s%s)- %s" % (self.file, i + 1,
-                stype, ptype, pmatch, lines[i])
+                output += "%s-%s %s - %s" % (self.file, i + 1,
+                ' ' * (2 + len(stype + ptype + pmatch)), lines[i])
         f.close()
         if mode == 'color':
             if have_pygments:


### PR DESCRIPTION
Yet another context management patch!
The idea is that context lines should not print the name and type of a matched variable since it does not contain any (by definition).
Spaces are added to respect output alignment.
