### PR TITLE
Add support for python 3.4

### DIFF
--- a/src/coccigrep.py
+++ b/src/coccigrep.py
@@ -464,7 +464,7 @@ for p in p1:
         tmp_cocci_file.flush()
 
         # launch spatch
-        output = ""
+        output = "".encode('utf8')
         # Launch parallel spatch
         if self.ncpus > 1 and len(files) > 1:
             fseq = []
@@ -484,12 +484,12 @@ for p in p1:
                 sprocess.start()
                 self.process.append(sprocess)
             for process in self.process:
-                ret = process.recv()
+                ret = process.recv().decode('utf8')
                 process.join()
                 if not ret.startswith('cexceptions\n'):
                     # CocciProcess return a serialized exception
                     # in case of exception
-                    output += ret
+                    output += ret.encode('utf8')
                     continue
                 import pickle
                 err = pickle.loads(ret)


### PR DESCRIPTION
Coccigrep fails to run on python 3.4 with the follwing error:

  Traceback (most recent call last):
    File "/usr/bin/coccigrep", line 143, in <module>
      coccigrep.run(files)
    File "/usr/lib/python3.4/site-packages/coccigrep/coccigrep.py", line 489, in run
      if not ret.startswith('cexceptions\n'):
  TypeError: startswith first arg must be bytes or a tuple of bytes, not str

This can be fixed by explicit conversions to/from utf8.