### PR TITLE
Fix syntax error in python3 environment.

### DIFF
--- a/src/coccigrep.py
+++ b/src/coccigrep.py
@@ -297,7 +297,7 @@ p1 << init.p1;
 @@
 
 for p in p1:
-    print "%s:%s:%s:%s:%s" % (p.file,p.line,p.column,p.line_end,p.column_end)
+    print("%s:%s:%s:%s:%s" % (p.file,p.line,p.column,p.line_end,p.column_end))
 """
 
     def __init__(self):


### PR DESCRIPTION
When I run coccigrep python3, I got following syntax error.

masami@saga:~$ coccigrep -v -t test_t test.c
Running: spatch --recursive-includes -sp_file /tmp/tmp0di5wo0y.cocci
test.c.
init_defs_builtins: /usr/lib/coccinelle/standard.h
HANDLING: test.c
  File "<string>", line 6
    print "%s:%s:%s:%s:%s" %
(p.file,p.line,p.column,p.line_end,p.column_end)
                         ^
SyntaxError: invalid syntax
while running simple python string:
from coccinelle import *
from coccilib.iteration import Iteration

for p in p1:
    print "%s:%s:%s:%s:%s" %
(p.file,p.line,p.column,p.line_end,p.column_end)
:
Failure in rule starting on line 19
Fatal error: exception Yes_pycocci.Pycocciexception
No match found in test.c

So, use print() style to support Python3.